### PR TITLE
Added bash and fish shell completions

### DIFF
--- a/scripts/shell_completions/bash/qk
+++ b/scripts/shell_completions/bash/qk
@@ -1,0 +1,64 @@
+# Completions for quikey
+# https://github.com/bostrt/quikey/
+# Copy this file to /usr/share/bash-completion/completions/ or /etc/bash_completion.d/
+
+_qk()
+{
+    compopt -o default
+    COMPREPLY=()
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local common_opts="--help"
+    local opts="${common_opts}"
+
+    # Commands
+    if [[ ${COMP_CWORD} == 1 ]] ; then
+        local qk_commands="start stop status add edit ls rm --help"
+        COMPREPLY=( $(compgen -W "${qk_commands}" -- ${cur}) )
+        compopt +o default
+        return 0
+    fi
+
+    if [[ ${cur} == -* ]] ; then
+        case "${COMP_LINE}" in
+            *' start '*)
+                local opts="${common_opts}"
+                ;;
+            *' status '*)
+                local opts="${common_opts}"
+                ;;
+            *' stop '*)
+                local opts="-n --name ${common_opts}"
+                ;;
+            *' add '*)
+                local opts="-n --name -t --tag -p --phrase ${common_opts}"
+                ;;
+            *' edit '*)
+                local opts="-n --name ${common_opts}"
+                ;;
+            *' ls '*)
+                local opts="--show-all ${common_opts}"
+                ;;
+            *' rm '*)
+                local opts="-n --name ${common_opts}"
+                ;;
+        esac
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+
+    if [[ ${prev} == -* ]] ; then
+        case "${prev}" in
+            '-n'|'--name')
+                local opts=`qk ls | grep '^| ' | cut -d ' ' -f 2 | tail -n '+2'`
+                ;;
+        esac
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+
+    return 0
+
+}
+
+complete -F _qk qk

--- a/scripts/shell_completions/fish/qk.fish
+++ b/scripts/shell_completions/fish/qk.fish
@@ -1,0 +1,18 @@
+# Completions for quikey
+# https://github.com/bostrt/quikey/
+# Copy this file to /usr/share/fish/vendor_completions.d/
+
+complete -c qk -f -n __fish_is_first_token -a 'start' -d 'Start the quikey daemon'
+complete -c qk -f -n __fish_is_first_token -a 'stop' -d 'Stop the quikey daemon'
+complete -c qk -f -n __fish_is_first_token -a 'status' -d 'Show a status report'
+complete -c qk -f -n __fish_is_first_token -a 'add' -d 'Add a new entry'
+complete -c qk -f -n __fish_is_first_token -a 'edit' -d 'Edit an existing entry'
+complete -c qk -f -n __fish_is_first_token -a 'ls' -d 'List (all) entries'
+complete -c qk -f -n __fish_is_first_token -a 'rm' -d 'Remove an entry'
+
+complete -c qk -f        -l 'help'     -d 'Show a help message and exit'
+
+complete -c qk -f -s 'n' -l 'name'     -d 'Name of quikey phrase' -a "(qk ls | grep '^| ' | cut -d ' ' -f 2 | tail -n '+2')" -n "__fish_seen_subcommand_from add edit rm"
+complete -c qk -f -s 't' -l 'tag'      -d 'Optional tag for the phrase'  -n "__fish_seen_subcommand_from add"
+complete -c qk -f -s 'p' -l 'phrase'   -d 'The full phrase to add'       -n "__fish_seen_subcommand_from add"
+complete -c qk -f        -l 'show-all' -d 'Show all entries'             -n "__fish_seen_subcommand_from ls"


### PR DESCRIPTION
I'm certainly not sure whether you like the folder structure, I just copied it from borg.
Also I realised that ```qk ls``` is rather too fancy for scripting, I had to use
```qk ls | grep '^| ' | cut -d ' ' -f 2 | tail -n '+2'```
for a simplified output. Could you maybe consider adding a --simple option to the ls command?
